### PR TITLE
Fix 0 permission initial state

### DIFF
--- a/src/GooglePlayAdvancedSearch/django/web/Api.py
+++ b/src/GooglePlayAdvancedSearch/django/web/Api.py
@@ -57,7 +57,16 @@ def search(request):
 
 	appInfos = searchGooglePlay(keyword)
 
+	needCompleteInfo = False
 	if len(excludedPIds):
+		needCompleteInfo = True
+	else:
+		with connection.cursor() as cursor:
+			permissions = GooglePlayAdvancedSearch.DBUtils.getAllPermissions(cursor)
+			if len(permissions) == 0:
+				needCompleteInfo = True
+
+	if needCompleteInfo:
 		# We have to run scraper
 		appInfos = getCompleteAppInfo([a['id'] for a in appInfos])
 		appInfos = [a for a in appInfos if isExcluded(a['permissions'], excludedPIds) == False]


### PR DESCRIPTION
# Bug

Steps to reproduce:

1. Delete database
2. Run website
3. Go to http://127.0.0.1:8000/


What you see is **No permission available**


User may search apps, but cannot filter by permissions.


This pull request fixes the bug. If there are no permissions in database, the website will pull full app information, which includes permissions.

